### PR TITLE
Separate property resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ import java.util.function.Predicate;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import civitz.viper.CdiConfiguration;
+import com.google.common.primitives.Ints;
+
+import viper.CdiConfiguration;
+import viper.PropertyFileResolver;
 
 /*
  * You can specify one or more annotations for the Configuration Bean.

--- a/generator/src/main/java/viper/generator/ConfigurationKeyProcessor.java
+++ b/generator/src/main/java/viper/generator/ConfigurationKeyProcessor.java
@@ -67,7 +67,6 @@ public class ConfigurationKeyProcessor extends AbstractProcessor {
 
 	@Override
 	public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-		// TODO Auto-generated method stub
 		processingEnv.getMessager().printMessage(Kind.NOTE, "called processing");
 		Set<? extends Element> elementsAnnotatedWith = roundEnv.getElementsAnnotatedWith(CdiConfiguration.class);
 		if (elementsAnnotatedWith.size() > 1) {
@@ -90,7 +89,6 @@ public class ConfigurationKeyProcessor extends AbstractProcessor {
 					Builder<String, Object> builder = ImmutableMap.<String, Object> builder()
 						.put("enumClass", className)
 						.put("packageName", packageName)
-//						.put("propertiesPath", propertiesPath)
 						.put("passedAnnotations", passedAnnotations);
 					
 					getValidatorMethod(classElement).ifPresent(method -> {
@@ -142,7 +140,7 @@ public class ConfigurationKeyProcessor extends AbstractProcessor {
 					}
 					
 				} catch (IOException e1) {
-					processingEnv.getMessager().printMessage(Kind.ERROR, "error creating file", e);
+					processingEnv.getMessager().printMessage(Kind.ERROR, "error creating files", e);
 				}
 
 			} else {
@@ -205,7 +203,7 @@ public class ConfigurationKeyProcessor extends AbstractProcessor {
 		}
 		Map<? extends ExecutableElement, ? extends AnnotationValue> elementValues = mirror.get().getElementValues();
 		Optional<? extends AnnotationValue> value = elementValues.entrySet().stream()
-			.filter(entry->entry.getKey().getSimpleName().toString().equals("value"))
+			.filter(entry -> entry.getKey().getSimpleName().toString().equals("value"))
 			.map(Entry::getValue)
 			.findFirst();
 		
@@ -217,7 +215,7 @@ public class ConfigurationKeyProcessor extends AbstractProcessor {
 		List<Object> annotations = (List<Object>) value.get().getValue();
 		return	annotations.stream()
 			.map(Object::toString)
-			.map(s->s.endsWith(".class")?s.substring(0, s.length()-6):s)
+			.map(s -> s.endsWith(".class") ? s.substring(0, s.length() - 6) : s)
 			.collect(toList());
 	}
 	

--- a/generator/src/main/resources/Configuration.vm
+++ b/generator/src/main/resources/Configuration.vm
@@ -1,13 +1,20 @@
 package ${packageName};
 
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 import javax.enterprise.util.Nonbinding;
 import javax.inject.Qualifier;
+import java.lang.annotation.Target;
 
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)
+@Target({FIELD,TYPE,METHOD,PARAMETER})
 public @interface Configuration {
 	@Nonbinding
 	${enumClass} value() default ${enumClass}.${nullValue};

--- a/generator/src/main/resources/ConfigurationBean.vm
+++ b/generator/src/main/resources/ConfigurationBean.vm
@@ -3,37 +3,25 @@ package ${packageName};
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Stream.concat;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Properties;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Inject;
+
+import viper.ConfigurationResolver;
 
 #foreach( $annotation in $passedAnnotations )
 @$annotation
 #end
 public class ConfigurationBean {
 
-	private static final String PROPERTIES_PATH = "${propertiesPath}";
-
-	Properties properties = new Properties();
+	@Inject
+	ConfigurationResolver<${enumClass}> resolver;
 
 	@PostConstruct
-	void init() {
-
-		Properties availableProperties = getAvailableProperties(PROPERTIES_PATH);
-
-		validateProperties(availableProperties);
-
-		properties.clear();
-		properties.putAll(availableProperties);
-	}
-
-	private void validateProperties(Properties availableProperties) {
+	void validateProperties() {
 		ArrayList<String> missing= new ArrayList<>();
 #if ( $validator ) 
 		ArrayList<String> invalid= new ArrayList<>();
@@ -44,8 +32,8 @@ public class ConfigurationBean {
 				continue;
 			}
 		
-			String key = enumToKeyString(config);
-			String property = availableProperties.getProperty(key);
+			//String key = enumToKeyString(config);
+			String property = resolver.getConfigurationValue(config);
 			
 			if (isNullOrEmpty(property)) {
 				missing.add(formatMissing(config));
@@ -66,7 +54,6 @@ public class ConfigurationBean {
 #end
 			throw new IllegalArgumentException("Configuration is invalid for these reason: " + reasons);
 		}
-			
 
 	}
 
@@ -78,13 +65,13 @@ public class ConfigurationBean {
 #end
 	}
 
-	private static String formatMissing(${enumClass} config) {
-		return "Property " + config.name() + " (" + enumToKeyString(config) + ") is missing";
+	private String formatMissing(${enumClass} config) {
+		return "Property " + config.name() + " (" + resolver.getConfigurationKey(config) + ") is missing";
 	}
 	
 #if ( $validator )
 	private String formatInvalid(${enumClass} config, String property) {
-		return "Property " + config.name() + " (" + enumToKeyString(config) + ") is invalid for value \"" + property
+		return "Property " + config.name() + " (" + resolver.getConfigurationKey(config) + ") is invalid for value \"" + property
 				+ "\"";
 	}
 
@@ -98,15 +85,6 @@ public class ConfigurationBean {
 		return s == null || s.trim().isEmpty();
 	}
 
-#if ( $keyString )
-	private static String enumToKeyString(${enumClass} e){
-		return e.${keyString};
-	}
-#else
-	private static String enumToKeyString(${enumClass} e){
-		return e.name().toLowerCase();
-	}
-#end
 
 	@Produces
 	@Configuration
@@ -117,22 +95,8 @@ public class ConfigurationBean {
 	}
 
 	public String getProperty(${enumClass} keyEnum) {
-		String keyString = enumToKeyString(keyEnum);
-		return properties.getProperty(keyString);
+		return resolver.getConfigurationValue(keyEnum);
 	}
 
-	private static Properties getAvailableProperties(String propertiesPath) {
-		File file = new File(propertiesPath);
-		if (!file.exists() || !file.canRead() || !file.isFile()) {
-			throw new IllegalArgumentException("Unable to read file " + propertiesPath);
-		}
-		Properties properties = new Properties();
-		try {
-			properties.load(new FileInputStream(file));
-		} catch (IOException e) {
-			throw new IllegalArgumentException("Unable to read file " + propertiesPath, e);
-		}
-		return properties;
-	}
 
 }

--- a/generator/src/main/resources/ConfigurationResolver.vm
+++ b/generator/src/main/resources/ConfigurationResolver.vm
@@ -1,0 +1,58 @@
+package ${packageName};
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+import javax.annotation.PostConstruct;
+
+import viper.ConfigurationResolver;
+
+public class PropertyFileConfigurationResolver implements ConfigurationResolver<${enumClass}> {
+
+	private static final String PROPERTIES_PATH = "${propertiesPath}";
+
+	Properties properties = new Properties();
+
+	@PostConstruct
+	void init() {
+		properties = getAvailableProperties(PROPERTIES_PATH);
+	}
+	
+	@Override
+	public String getConfigurationValue(${enumClass} key) {
+		return properties.getProperty(enumToKeyString(key));
+	}
+	
+	@Override
+	public String getConfigurationKey(${enumClass} key) {
+		return enumToKeyString(key);
+	}
+	
+	
+#if ( $keyString )
+	private static String enumToKeyString(${enumClass} e){
+		return e.${keyString};
+	}
+#else
+	private static String enumToKeyString(${enumClass} e){
+		return e.name().toLowerCase();
+	}
+#end
+	
+	private static Properties getAvailableProperties(String propertiesPath) {
+		File file = new File(propertiesPath);
+		if (!file.exists() || !file.canRead() || !file.isFile()) {
+			throw new IllegalArgumentException("Unable to read file " + propertiesPath);
+		}
+		Properties properties = new Properties();
+		try {
+			properties.load(new FileInputStream(file));
+		} catch (IOException e) {
+			throw new IllegalArgumentException("Unable to read file " + propertiesPath, e);
+		}
+		return properties;
+	}
+}
+

--- a/generatortests/pom.xml
+++ b/generatortests/pom.xml
@@ -47,12 +47,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.jboss.weld</groupId>
-			<artifactId>weld-junit4</artifactId>
-			<version>1.0.0.Final</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.jboss.weld.se</groupId>
 			<artifactId>weld-se</artifactId>
 			<version>1.1.9.Final</version>

--- a/generatortests/pom.xml
+++ b/generatortests/pom.xml
@@ -46,6 +46,19 @@
 			<version>1.0</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.jboss.weld</groupId>
+			<artifactId>weld-junit4</artifactId>
+			<version>1.0.0.Final</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.jboss.weld.se</groupId>
+			<artifactId>weld-se</artifactId>
+			<version>1.1.9.Final</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/generatortests/src/test/java/viper/generatortests/CompleteEnum.java
+++ b/generatortests/src/test/java/viper/generatortests/CompleteEnum.java
@@ -7,13 +7,15 @@ import javax.enterprise.context.ApplicationScoped;
 import com.google.common.primitives.Ints;
 
 import viper.CdiConfiguration;
+import viper.PropertyFileResolver;
 
 /*
  * You can specify one or more annotations for the Configuration Bean.
  * In this case, Configuration Bean will have the ApplicationScoped qualifier
  */
 @CdiConfiguration.PassAnnotations(ApplicationScoped.class)
-@CdiConfiguration(propertiesPath="/opt/generatortests/config.properties")
+@CdiConfiguration
+@PropertyFileResolver(propertiesPath = "/tmp/viper/my.config")
 public enum CompleteEnum {
 	FIRST_PROPERTY("my.particular.key", s -> Ints.tryParse(s) != null),
 	SECOND_PROPERTY("my.other.key", s -> s.length() >= 10),
@@ -51,7 +53,7 @@ public enum CompleteEnum {
 	 * You can specify a method to get a particular string value as a property
 	 * key instead of the generic enum constant name in lowercase.
 	 */
-	@CdiConfiguration.KeyString
+	@PropertyFileResolver.KeyString
 	public String getKeyString() {
 		return key;
 	}

--- a/generatortests/src/test/java/viper/generatortests/ConfigurationBeanTest.java
+++ b/generatortests/src/test/java/viper/generatortests/ConfigurationBeanTest.java
@@ -4,6 +4,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
+import viper.ConfigurationResolver;
+import viper.generator.ConfigurationKeyProcessor;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+
+import javax.tools.JavaCompiler;
+import javax.tools.JavaCompiler.CompilationTask;
+import javax.tools.JavaFileObject;
+import javax.tools.JavaFileObject.Kind;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
+
+
 public class ConfigurationBeanTest {
 	@Test
 	public void shouldGeneratedConfigurationBeanClass() throws Exception {
@@ -22,5 +40,42 @@ public class ConfigurationBeanTest {
 			.isAnnotation()
 			.isNotNull();
 	}
+	
+	@Test
+	public void shouldGeneratedPropertyFileConfigurationResolver() throws Exception {
+		String className = CompleteEnum.class.getPackage().getName() + ".PropertyFileConfigurationResolver";
+		Class<?> confBeanClass = Class.forName(className);
+		assertThat(confBeanClass)
+			.isNotAnnotation()
+			.isNotNull();
+		
+		assertThat(ConfigurationResolver.class.isAssignableFrom(confBeanClass))
+			.as("Generated file should be an interface extending " + ConfigurationResolver.class.getSimpleName())
+			.isTrue();
+	}
+	
+     @Test
+     public void runAnnoationProcessor() throws Exception {
+             String source = "src/test/";
+
+             Iterable<JavaFileObject> files = getSourceFiles(source);
+
+             JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+
+             CompilationTask task = compiler.getTask(new PrintWriter(System.out), null, null, null, null, files);
+             task.setProcessors(Arrays.asList(new ConfigurationKeyProcessor()));
+
+             task.call();
+     }
+
+     private Iterable<JavaFileObject> getSourceFiles(String p_path) throws Exception {
+             JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+             StandardJavaFileManager files = compiler.getStandardFileManager(null, null, null);
+             files.setLocation(StandardLocation.SOURCE_PATH, Arrays.asList(new File(p_path)));
+
+             Set<Kind> fileKinds = Collections.singleton(Kind.SOURCE);
+             return files.list(StandardLocation.SOURCE_PATH, "", fileKinds, true);
+     }
+
 	
 }

--- a/generatortests/src/test/java/viper/generatortests/ConfigurationBeanTest.java
+++ b/generatortests/src/test/java/viper/generatortests/ConfigurationBeanTest.java
@@ -1,17 +1,23 @@
 package viper.generatortests;
 
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import viper.ConfigurationResolver;
 import viper.generator.ConfigurationKeyProcessor;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Set;
+import java.util.List;
 
 import javax.tools.JavaCompiler;
 import javax.tools.JavaCompiler.CompilationTask;
@@ -23,6 +29,10 @@ import javax.tools.ToolProvider;
 
 
 public class ConfigurationBeanTest {
+	
+	@Rule
+	public TemporaryFolder temp = new TemporaryFolder();
+	
 	@Test
 	public void shouldGeneratedConfigurationBeanClass() throws Exception {
 		String className = CompleteEnum.class.getPackage().getName() + ".ConfigurationBean";
@@ -53,29 +63,61 @@ public class ConfigurationBeanTest {
 			.as("Generated file should be an interface extending " + ConfigurationResolver.class.getSimpleName())
 			.isTrue();
 	}
-	
-     @Test
-     public void runAnnoationProcessor() throws Exception {
-             String source = "src/test/";
 
-             Iterable<JavaFileObject> files = getSourceFiles(source);
+	@Test
+	public void shouldRunAnnotationProcessor() throws Exception {
+		final String enumToCompile = "CompleteEnum.java";
 
-             JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+		/*
+		 * Note to future dev: this is intended both as a test and as a way to
+		 * debug future versions of the annotation processor.
+		 * 
+		 * You can use it to test different enum variation, and my hope is to
+		 * extend the tests by putting "java" files in resources directory, and
+		 * manually call the compiler here.
+		 * 
+		 */
+		
+		File sourceDir = temp.newFolder("sources");
+		File outputDir = temp.newFolder("classes");
+		File generatedSourcesDir = temp.newFolder("generated");
 
-             CompilationTask task = compiler.getTask(new PrintWriter(System.out), null, null, null, null, files);
-             task.setProcessors(Arrays.asList(new ConfigurationKeyProcessor()));
+		Path source = Paths.get("src", "test", "java", "viper", "generatortests", enumToCompile);
+		Path destinationDir = Paths.get(sourceDir.getAbsolutePath(), "viper", "generatortests");
+		Files.createDirectories(destinationDir);
+		Files.copy(source, destinationDir.resolve(enumToCompile));
 
-             task.call();
-     }
+		// combine compiler
+		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+		StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null);
+		fileManager.setLocation(StandardLocation.SOURCE_PATH, Arrays.asList(sourceDir));
+		fileManager.setLocation(StandardLocation.CLASS_OUTPUT, Arrays.asList(outputDir));
+		fileManager.setLocation(StandardLocation.SOURCE_OUTPUT, Arrays.asList(generatedSourcesDir));
 
-     private Iterable<JavaFileObject> getSourceFiles(String p_path) throws Exception {
-             JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-             StandardJavaFileManager files = compiler.getStandardFileManager(null, null, null);
-             files.setLocation(StandardLocation.SOURCE_PATH, Arrays.asList(new File(p_path)));
+		// get files to be compiled
+		Iterable<JavaFileObject> files = fileManager.list(StandardLocation.SOURCE_PATH, "",
+				Collections.singleton(Kind.SOURCE), true);
 
-             Set<Kind> fileKinds = Collections.singleton(Kind.SOURCE);
-             return files.list(StandardLocation.SOURCE_PATH, "", fileKinds, true);
-     }
+		// setup compilation task
+		CompilationTask task = compiler.getTask(new PrintWriter(System.out), fileManager, null, null, null, files);
+		task.setProcessors(Arrays.asList(new ConfigurationKeyProcessor()));
 
+		// compile
+		Boolean result = task.call();
+
+		assertThat(result)
+			.as("Compile task should work on example enum")
+			.isTrue();
+
+		List<String> javaGeneratedFiles = Files.walk(generatedSourcesDir.toPath())
+			.filter(p->p.toFile().isFile())
+			.filter(p->p.getFileName().toString().endsWith(".java"))
+			.map(p->p.getFileName())
+			.map(p->p.toString())
+			.collect(toList());
+
+		assertThat(javaGeneratedFiles)
+			.contains("ConfigurationBean.java", "Configuration.java", "PropertyFileConfigurationResolver.java");
+	}
 	
 }

--- a/library/src/main/java/viper/CdiConfiguration.java
+++ b/library/src/main/java/viper/CdiConfiguration.java
@@ -48,8 +48,6 @@ import java.util.function.Predicate;
  * <p>
  * Use sub-annotations to obtain specific variants of the configuration bean:
  * <ul>
- * <li>{@link KeyString} to specify a method to extract the key string of a
- * property, instead of the default value</li>
  * <li>{@link KeyNullValue} to specify a different enum constant to use as null
  * value</li>
  * <li>{@link ConfigValidator} to specify a different null value for the enum
@@ -62,17 +60,6 @@ import java.util.function.Predicate;
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface CdiConfiguration {
-
-	String propertiesPath();
-
-	/**
-	 * Specifies a method to obtain the key in place of
-	 * <code>enumConstant.name().toLowerCase()</code>
-	 */
-	@Retention(RetentionPolicy.SOURCE)
-	@Target({ ElementType.METHOD })
-	public static @interface KeyString {
-	}
 
 	/**
 	 * Specifies an enum constant to be used as the null constant, i.e. a

--- a/library/src/main/java/viper/ConfigurationResolver.java
+++ b/library/src/main/java/viper/ConfigurationResolver.java
@@ -1,7 +1,39 @@
 package viper;
 
+/**
+ * An interface to resolve configuration values from an enum representing its
+ * keys.
+ *
+ * @param <E>
+ *            The enum containing the keys
+ */
 public interface ConfigurationResolver<E extends Enum<E>> {
+
+	/**
+	 * Returns a string value of the configuration key passed as a parameter.
+	 * 
+	 * @param key
+	 *            the configuration key.
+	 * @return the configuration value.
+	 */
 	String getConfigurationValue(E key);
-	
-	String getConfigurationKey(E key);
+
+	/**
+	 * Returns a string representation of the key.
+	 * <p>
+	 * Use this if your key can be represented in a particular way. E.g. you are
+	 * using a property file and all your configurations have a particular
+	 * prefix.
+	 * <p>
+	 * This method will be called if, for a particular key, no value is found,
+	 * or the value is not valid: the string returned will be used to construct
+	 * the error message, along with the enum key name.
+	 * 
+	 * @param key
+	 *            the configuration key.
+	 * @return a string representation of the key.
+	 */
+	default String getConfigurationKey(E key) {
+		return key.name();
+	};
 }

--- a/library/src/main/java/viper/ConfigurationResolver.java
+++ b/library/src/main/java/viper/ConfigurationResolver.java
@@ -1,0 +1,7 @@
+package viper;
+
+public interface ConfigurationResolver<E extends Enum<E>> {
+	String getConfigurationValue(E key);
+	
+	String getConfigurationKey(E key);
+}

--- a/library/src/main/java/viper/PropertyFileResolver.java
+++ b/library/src/main/java/viper/PropertyFileResolver.java
@@ -1,0 +1,23 @@
+package viper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+public @interface PropertyFileResolver {
+	String propertiesPath();
+	
+
+	/**
+	 * Specifies a method to obtain the key in place of
+	 * <code>enumConstant.name().toLowerCase()</code>
+	 */
+	@Retention(RetentionPolicy.SOURCE)
+	@Target({ ElementType.METHOD })
+	public static @interface KeyString {
+	}
+
+}


### PR DESCRIPTION
This provides a `ConfigurationResolver<E extends Enum>` interface for resolving properties from the enum. A generic implementation based on `java.util.Properties` can be generated via annotation processor: it will be the same as before, but now it will have its own annotations.

This PR will also let the users inject their own implementation of ConfigurationResolver (e.g. etcd-based, JMX based, you name it...).

Closes #12