### PR TITLE
Permit generation of multiple configuration beans

### DIFF
--- a/generator/src/main/java/viper/generator/ConfigurationKeyProcessor.java
+++ b/generator/src/main/java/viper/generator/ConfigurationKeyProcessor.java
@@ -69,9 +69,6 @@ public class ConfigurationKeyProcessor extends AbstractProcessor {
 	public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
 		processingEnv.getMessager().printMessage(Kind.NOTE, "called processing");
 		Set<? extends Element> elementsAnnotatedWith = roundEnv.getElementsAnnotatedWith(CdiConfiguration.class);
-		if (elementsAnnotatedWith.size() > 1) {
-			processingEnv.getMessager().printMessage(Kind.ERROR, "more than one element per type CdiConfiguration");
-		}
 		for (Element e : elementsAnnotatedWith) {
 			if (e.getKind() == ElementKind.ENUM) {
 				try {
@@ -80,7 +77,7 @@ public class ConfigurationKeyProcessor extends AbstractProcessor {
 					PackageElement packageElement = (PackageElement) classElement.getEnclosingElement();
 
 					// properties for cdi configuration 
-					String className = classElement.getSimpleName().toString();
+					final String className = classElement.getSimpleName().toString();
 					boolean producersForPrimitives = classElement.getAnnotation(CdiConfiguration.class).producersForPrimitives();
 
 					List<String> passedAnnotations = getPassedAnnotations(classElement);
@@ -116,14 +113,14 @@ public class ConfigurationKeyProcessor extends AbstractProcessor {
 					
 					Template config = generateTemplateFor("Configuration.vm", props);
 					JavaFileObject configSourceFile = processingEnv.getFiler()
-							.createSourceFile(packageName + ".Configuration", e);
+							.createSourceFile(packageName + "." + className + "Configuration", e);
 					Writer configWriter = configSourceFile.openWriter();
 					config.merge(contextFromProperties(props), configWriter);
 					configWriter.flush();
 					configWriter.close();
 
 					JavaFileObject configBeanSourceFile = processingEnv.getFiler()
-							.createSourceFile(packageName + ".ConfigurationBean", e);
+							.createSourceFile(packageName + "." + className + "ConfigurationBean", e);
 					Template configBean = generateTemplateFor("ConfigurationBean.vm", props);
 					Writer configBeanWriter = configBeanSourceFile.openWriter();
 					configBean.merge(contextFromProperties(props), configBeanWriter);
@@ -134,7 +131,7 @@ public class ConfigurationKeyProcessor extends AbstractProcessor {
 					// generate property file resolver if needed
 					if(propertyFileResolver.isPresent()){
 						JavaFileObject propertyFileResolverSourceFile = processingEnv.getFiler()
-								.createSourceFile(packageName + ".PropertyFileConfigurationResolver", e);
+								.createSourceFile(packageName + "." + className + "PropertyFileConfigurationResolver", e);
 						Template propertyFileResolverTemplate = generateTemplateFor("ConfigurationResolver.vm", props);
 						Writer propertyFileResolverWriter = propertyFileResolverSourceFile.openWriter();
 						propertyFileResolverTemplate.merge(contextFromProperties(props), propertyFileResolverWriter);

--- a/generator/src/main/resources/Configuration.vm
+++ b/generator/src/main/resources/Configuration.vm
@@ -17,7 +17,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({FIELD,TYPE,METHOD,PARAMETER})
 @Generated("$generatorName")
-public @interface Configuration {
+public @interface ${enumClass}Configuration {
 	@Nonbinding
 	${enumClass} value() default ${enumClass}.${defaultKey};
 }

--- a/generator/src/main/resources/ConfigurationBean.vm
+++ b/generator/src/main/resources/ConfigurationBean.vm
@@ -17,7 +17,7 @@ import viper.ConfigurationResolver;
 @$annotation
 #end
 @Generated("$generatorName")
-public class ConfigurationBean {
+public class ${enumClass}ConfigurationBean {
 
 	@Inject
 	ConfigurationResolver<${enumClass}> resolver;
@@ -79,12 +79,12 @@ public class ConfigurationBean {
 	}
 	
 	private ${enumClass} getEnumFromInjectionPoint(InjectionPoint ip) {
-		Configuration annotation = ip.getAnnotated().getAnnotation(Configuration.class);
+		${enumClass}Configuration annotation = ip.getAnnotated().getAnnotation(${enumClass}Configuration.class);
 		return annotation.value();
 	}
 
 	@Produces
-	@Configuration
+	@${enumClass}Configuration
 	private String getStringProperty(InjectionPoint ip) {
 		${enumClass} keyEnum = getEnumFromInjectionPoint(ip);
 		return getProperty(keyEnum);
@@ -93,7 +93,7 @@ public class ConfigurationBean {
 #if ( $producersForPrimitives )
 #foreach ($type in ["Byte", "Short", "Integer", "Long", "Float", "Double", "Boolean"])
 	@Produces
-	@Configuration
+	@${enumClass}Configuration
 	private ${type} get${type}Property(InjectionPoint ip) {
 		String stringProperty = getStringProperty(ip);
 		return ${type}.valueOf(stringProperty);
@@ -101,7 +101,7 @@ public class ConfigurationBean {
 #end
 	
 	@Produces
-	@Configuration
+	@${enumClass}Configuration
 	private Character getCharacterProperty(InjectionPoint ip) {
 		String stringProperty = getStringProperty(ip);
 		return stringProperty.charAt(0);

--- a/generator/src/main/resources/ConfigurationResolver.vm
+++ b/generator/src/main/resources/ConfigurationResolver.vm
@@ -11,7 +11,7 @@ import javax.annotation.PostConstruct;
 import viper.ConfigurationResolver;
 
 @Generated("$generatorName")
-public class PropertyFileConfigurationResolver implements ConfigurationResolver<${enumClass}> {
+public class ${enumClass}PropertyFileConfigurationResolver implements ConfigurationResolver<${enumClass}> {
 
 	private static final String PROPERTIES_PATH = "${propertiesPath}";
 

--- a/generatortests/src/test/java/viper/generatortests/CompleteEnumTest.java
+++ b/generatortests/src/test/java/viper/generatortests/CompleteEnumTest.java
@@ -77,6 +77,8 @@ public class CompleteEnumTest {
 	private static File generatedSourcesDir;
 	
 	URLClassLoader outputClassLoader;
+	
+	final String enumClassName = "CompleteEnum";
 
 	@BeforeClass
 	public static void setUpClass() throws Exception{
@@ -97,7 +99,7 @@ public class CompleteEnumTest {
 	
 	@Test // starts with "_" for method ordering
 	public void _shouldRunAnnotationProcessor() throws Exception {
-		final String enumToCompile = "CompleteEnum.java";
+		final String enumToCompile = enumClassName+".java";
 
 		/*
 		 * Note to future dev: this is intended both as a test and as a way to
@@ -144,8 +146,12 @@ public class CompleteEnumTest {
 			.collect(toList());
 
 		assertThat(javaGeneratedFiles)
-			.as("Chould generate annotation, configuration bean, and property file config resolver")
-			.contains("ConfigurationBean.java", "Configuration.java", "PropertyFileConfigurationResolver.java");
+			.as("Could generate annotation, configuration bean, and property file config resolver")
+			.contains(
+					enumClassName + "Configuration.java", // the annotation
+					enumClassName + "ConfigurationBean.java", // the injection
+					enumClassName + "PropertyFileConfigurationResolver.java" // the property file resolver
+				);
 		annotationProcessorHasRunSuccesfully = true;
 	}
 	
@@ -153,7 +159,7 @@ public class CompleteEnumTest {
 	@Test
 	public void shouldGenerateConfigurationBeanClass() throws Exception {
 		assumingAnnotationProcessorHasRun();
-		String className = packageName + ".ConfigurationBean";
+		String className = packageName + "." + enumClassName + "ConfigurationBean";
 		Class<?> confBeanClass = tryLoadClassFromCompiledFiles(className).orElse(null);
 		assertThat(confBeanClass)
 			.isNotNull()
@@ -185,8 +191,8 @@ public class CompleteEnumTest {
 	public void shouldGenerateAllProducerMethodsForConfigurationBean() throws Exception {
 		assumingAnnotationProcessorHasRun();
 		
-		String beanClassName = packageName + ".ConfigurationBean";
-		String annotationClassName = packageName + ".Configuration";
+		String beanClassName = packageName + "." + enumClassName + "ConfigurationBean";
+		String annotationClassName = packageName + "." + enumClassName + "Configuration";
 
 		Optional<Class<?>> beanClass = tryLoadClassFromCompiledFiles(beanClassName);
 		Optional<Class<? extends Annotation>> annotationClass = tryLoadClassFromCompiledFiles(annotationClassName);
@@ -224,7 +230,7 @@ public class CompleteEnumTest {
 	@Test
 	public void shouldGenerateConfigurationAnnotation() throws Exception {
 		assumingAnnotationProcessorHasRun();
-		String className = packageName + ".Configuration";
+		String className = packageName + "." + enumClassName + "Configuration";
 		Class<?> confBeanClass = tryLoadClassFromCompiledFiles(className).orElse(null);
 		assertThat(confBeanClass)
 			.isAnnotation()
@@ -241,7 +247,7 @@ public class CompleteEnumTest {
 	@Test
 	public void shouldGeneratePropertyFileConfigurationResolver() throws Exception {
 		assumingAnnotationProcessorHasRun();
-		String className = packageName + ".PropertyFileConfigurationResolver";
+		String className = packageName + "." + enumClassName + "PropertyFileConfigurationResolver";
 		Class<?> confBeanClass = tryLoadClassFromCompiledFiles(className).orElse(null);
 		assertThat(confBeanClass)
 			.isNotAnnotation()
@@ -262,7 +268,7 @@ public class CompleteEnumTest {
 	@Test
 	public void shouldAddGeneratedAnnotationToGeneratedSourceCode_propertyFileResolver() throws Exception {
 		assumingAnnotationProcessorHasRun();
-		final File generatedPropertyResolver = findFileInGeneratedSources("PropertyFileConfigurationResolver.java");
+		final File generatedPropertyResolver = findFileInGeneratedSources(enumClassName + "PropertyFileConfigurationResolver.java");
 		CompilationUnit compilationUnit = JavaParser.parse(generatedPropertyResolver);
 		TypeDeclaration typeDeclaration = compilationUnit.getTypes().get(0);
 
@@ -273,7 +279,7 @@ public class CompleteEnumTest {
 	@Test
 	public void shouldAddGeneratedAnnotationToGeneratedSourceCode_configurationBean() throws Exception {
 		assumingAnnotationProcessorHasRun();
-		File generatedConfigurationBean = findFileInGeneratedSources("ConfigurationBean.java");
+		File generatedConfigurationBean = findFileInGeneratedSources(enumClassName + "ConfigurationBean.java");
 		CompilationUnit compilationUnit = JavaParser.parse(generatedConfigurationBean);
 		TypeDeclaration typeDeclaration = compilationUnit.getTypes().get(0);
 
@@ -284,7 +290,7 @@ public class CompleteEnumTest {
 	@Test
 	public void shouldAddGeneratedAnnotationToGeneratedSourceCode_configurationAnnotation() throws Exception {
 		assumingAnnotationProcessorHasRun();
-		File generatedConfigurationBean = findFileInGeneratedSources("Configuration.java");
+		File generatedConfigurationBean = findFileInGeneratedSources(enumClassName + "Configuration.java");
 		CompilationUnit compilationUnit = JavaParser.parse(generatedConfigurationBean);
 		TypeDeclaration typeDeclaration = compilationUnit.getTypes().get(0);
 

--- a/generatortests/src/test/java/viper/generatortests/MultipleEnumCoexistenceTest.java
+++ b/generatortests/src/test/java/viper/generatortests/MultipleEnumCoexistenceTest.java
@@ -1,0 +1,147 @@
+package viper.generatortests;
+
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.tools.JavaCompiler;
+import javax.tools.JavaCompiler.CompilationTask;
+import javax.tools.JavaFileObject;
+import javax.tools.JavaFileObject.Kind;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runners.MethodSorters;
+
+import com.google.common.collect.Lists;
+
+import viper.generator.ConfigurationKeyProcessor;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class MultipleEnumCoexistenceTest {
+	@ClassRule
+	public static TemporaryFolder temp = new TemporaryFolder();
+
+	public static boolean annotationProcessorHasRunSuccesfully = false;
+
+	private static File sourceDir;
+	private static File outputDir;
+	private static File generatedSourcesDir;
+
+	@BeforeClass
+	public static void setUpClass() throws Exception{
+		sourceDir = temp.newFolder("sources");
+		outputDir = temp.newFolder("classes");
+		generatedSourcesDir = temp.newFolder("generated");
+	}
+
+	final List<String> enumClassesNames = Lists.newArrayList(
+			CompleteEnum.class.getSimpleName(),
+			SimplestEnum.class.getSimpleName()
+		);
+
+	@Test // starts with "_" for method ordering
+	public void _shouldRunAnnotationProcessor() throws Exception {
+		Path destinationDir = Paths.get(sourceDir.getAbsolutePath(), "viper", "generatortests");
+		Files.createDirectories(destinationDir);
+		for (String name : enumClassesNames) {
+			String enumToCompile = name + ".java";
+			Path source = Paths.get("src", "test", "java", "viper", "generatortests", enumToCompile);
+			Files.copy(source, destinationDir.resolve(enumToCompile));
+		}
+
+		// combine compiler
+		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+		StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null);
+		fileManager.setLocation(StandardLocation.SOURCE_PATH, Arrays.asList(sourceDir));
+		fileManager.setLocation(StandardLocation.CLASS_OUTPUT, Arrays.asList(outputDir));
+		fileManager.setLocation(StandardLocation.SOURCE_OUTPUT, Arrays.asList(generatedSourcesDir));
+
+		// get files to be compiled
+		Iterable<JavaFileObject> files = fileManager.list(StandardLocation.SOURCE_PATH, "",
+				Collections.singleton(Kind.SOURCE), true);
+
+		// setup compilation task
+		CompilationTask task = compiler.getTask(new PrintWriter(System.out), fileManager, null, null, null, files);
+		task.setProcessors(Arrays.asList(new ConfigurationKeyProcessor()));
+
+		// compile
+		Boolean result = task.call();
+
+		assertThat(result)
+			.as("Compile task should work on complete enum")
+			.isTrue();
+		annotationProcessorHasRunSuccesfully = true;
+	}
+
+	@Test
+	public void shouldCompileClassesForCompleteEnum() throws Exception {
+		assumingAnnotationProcessorHasRun();
+		String enumClassName = CompleteEnum.class.getSimpleName();
+		List<String> javaGeneratedFiles = getListOfGeneratedJavaFiles();
+
+		assertThat(javaGeneratedFiles)
+			.as("Could generate annotation, configuration bean, "
+					+ "and property file config resolver for "
+					+ enumClassName)
+			.contains(
+					enumClassName + "Configuration.java", // the annotation
+					enumClassName + "ConfigurationBean.java", // the injection
+					enumClassName + "PropertyFileConfigurationResolver.java" // the property file resolver
+				);
+	}
+
+	public List<String> getListOfGeneratedJavaFiles() throws IOException {
+		return Files.walk(generatedSourcesDir.toPath())
+				.filter(p -> p.toFile().isFile())
+				.filter(p -> p.getFileName().toString().endsWith(".java"))
+				.map(p -> p.getFileName())
+				.map(p -> p.toString())
+				.collect(toList());
+	}
+
+	@Test
+	public void shouldCompileClassesForSimplestEnum() throws Exception {
+		assumingAnnotationProcessorHasRun();
+		String enumClassName = SimplestEnum.class.getSimpleName();
+		List<String> javaGeneratedFiles = getListOfGeneratedJavaFiles();
+
+		assertThat(javaGeneratedFiles)
+			.as("Could generate annotation, configuration bean, "
+					+ "and NO property file config resolver for "
+					+ enumClassName)
+			.contains(
+					enumClassName + "Configuration.java", // the annotation
+					enumClassName + "ConfigurationBean.java" // the injection
+				)
+			.doesNotContain(
+					enumClassName + "PropertyFileConfigurationResolver.java" // the property file resolver
+				);
+	}
+	
+	/*
+	 * I know, this method is a really ugly way to skip tests if annotation
+	 * processor didn't run. But it works.
+	 * Also, I tried with JExample, but it didn't work well with @ClassRule
+	 */
+	public void assumingAnnotationProcessorHasRun() {
+		assumeTrue("Annotation should have run succesfully for this test to run...",
+				annotationProcessorHasRunSuccesfully);
+	}
+}

--- a/generatortests/src/test/java/viper/generatortests/SimplestEnum.java
+++ b/generatortests/src/test/java/viper/generatortests/SimplestEnum.java
@@ -1,0 +1,10 @@
+package viper.generatortests;
+
+import viper.CdiConfiguration;
+
+@CdiConfiguration
+public enum SimplestEnum {
+	NAME,
+	AGE,
+	LOCATION;
+}


### PR DESCRIPTION
By providing a different naming strategy, we open the way to multiple
configurations.

New strategy is {enumClass}Configuration, {enumClass}ConfigurationBean,
and so on...

Added tests to ensure that the coexistence is permitted.

Closes #6