### PR TITLE
Permit null, optional values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+*.iml
+.idea

--- a/generator/src/main/resources/ConfigurationBean.vm
+++ b/generator/src/main/resources/ConfigurationBean.vm
@@ -22,43 +22,22 @@ public class ${enumClass}ConfigurationBean {
 	@Inject
 	ConfigurationResolver<${enumClass}> resolver;
 
+#if ( $validator )
 	@PostConstruct
 	void validateProperties() {
-		ArrayList<String> missing= new ArrayList<>();
-#if ( $validator ) 
 		ArrayList<String> invalid= new ArrayList<>();
-#end
-		
 		for (${enumClass} config : ${enumClass}.values()) {
 			String property = resolver.getConfigurationValue(config);
-			
-			if (isNullOrEmpty(property)) {
-				missing.add(formatMissing(config));
-			}  
-#if ( $validator ) 
-			else if (!isValid(config, property)) {
+			if (!isValid(config, property)) {
 				invalid.add(formatInvalid(config, property));
 			}
-#end
 		}
-			
-#if ( $validator )
-		if (missing.size() > 0 || invalid.size() > 0) {
-			String reasons = concat(missing.stream(), invalid.stream()).collect(joining(", "));
-#else
-		if (missing.size() > 0) {
-			String reasons = missing.stream().collect(joining(", "));
-#end
+		if (invalid.size() > 0) {
+			String reasons = invalid.stream().collect(joining(", "));
 			throw new IllegalArgumentException("Configuration is invalid for these reason: " + reasons);
 		}
-
 	}
 
-	private String formatMissing(${enumClass} config) {
-		return "Property " + config.name() + " (" + resolver.getConfigurationKey(config) + ") is missing";
-	}
-	
-#if ( $validator )
 	private String formatInvalid(${enumClass} config, String property) {
 		return "Property " + config.name() + " (" + resolver.getConfigurationKey(config) + ") is invalid for value \"" + property
 				+ "\"";
@@ -67,12 +46,7 @@ public class ${enumClass}ConfigurationBean {
 	private static boolean isValid(${enumClass} config, String property) {
 		return config.${validator}.test(property);
 	}
-	
 #end
-
-	private static boolean isNullOrEmpty(String s) {
-		return s == null || s.trim().isEmpty();
-	}
 
 	public String getProperty(${enumClass} keyEnum) {
 		return resolver.getConfigurationValue(keyEnum);

--- a/generatortests/src/test/java/viper/generatortests/CompleteEnumTest.java
+++ b/generatortests/src/test/java/viper/generatortests/CompleteEnumTest.java
@@ -70,7 +70,7 @@ public class CompleteEnumTest {
 	
 	private static final String packageName = CompleteEnum.class.getPackage().getName();
 	
-	public static boolean annotationProcessorHasRunSuccesfully = false;
+	private static boolean annotationProcessorHasRunSuccessfully = false;
 
 	private static File sourceDir;
 	private static File outputDir;
@@ -152,7 +152,7 @@ public class CompleteEnumTest {
 					enumClassName + "ConfigurationBean.java", // the injection
 					enumClassName + "PropertyFileConfigurationResolver.java" // the property file resolver
 				);
-		annotationProcessorHasRunSuccesfully = true;
+		annotationProcessorHasRunSuccessfully = true;
 	}
 	
 	@SuppressWarnings("rawtypes")
@@ -208,10 +208,6 @@ public class CompleteEnumTest {
 					hasName("isValid"), 
 					hasParametersOfType(CompleteEnum.class, String.class),
 					isStatic()))
-			.has(aMethodThat("formats a message for missing properties", 
-					hasName("formatMissing"),
-					hasParametersOfType(CompleteEnum.class),
-					isStatic().negate()))
 			.has(aMethodThat("formats a message for invalid properties", 
 					hasName("formatInvalid"),
 					hasParametersOfType(CompleteEnum.class, String.class),
@@ -339,7 +335,7 @@ public class CompleteEnumTest {
 	 */
 	public void assumingAnnotationProcessorHasRun() {
 		assumeTrue("Annotation should have run succesfully for this test to run...",
-				annotationProcessorHasRunSuccesfully);
+				annotationProcessorHasRunSuccessfully);
 	}
 	
 	


### PR DESCRIPTION
Removed the missing value check: validation is now the only way to filter both missing and invalid values.
Therefore:

* we can inject null values #33
* missing values and invalid values are treated the same
* optional values can be handled with a custom property resolver #4
* normalization can happen in a custom resolver #27

On the plus side:

* the `ConfigurationBean` template is now a lot simpler, easier to mantain.
* in the simplest configuration, the library generates very little code: the bare minimum required to read and inject String properties using an enum-based annotation, which is the original scope of viper