### PR TITLE
More logging

### DIFF
--- a/generator/src/main/java/viper/generator/ConfigurationKeyProcessor.java
+++ b/generator/src/main/java/viper/generator/ConfigurationKeyProcessor.java
@@ -26,7 +26,6 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
-import javax.tools.Diagnostic;
 import javax.tools.Diagnostic.Kind;
 import javax.tools.JavaFileObject;
 


### PR DESCRIPTION
I have deliberately ignored `printMessage(Kind, String, Element)` as it prints out the original code along side the note, for example:
```
/tmp/junit5348738584239966288/sources/viper/generatortests/CompleteEnum.java:29: Note: CompleteEnum: Gathering information for code generation
public enum CompleteEnum {
       ^
/tmp/junit5348738584239966288/sources/viper/generatortests/CompleteEnum.java:29: Note: CompleteEnum: Class prefix for generated classes will be "CompleteEnum"
public enum CompleteEnum {
       ^
```
As you can see, it seems like an error, but it isn't.

The log style i went with is:
```
Note: Called processing on elements: [viper.generatortests.CompleteEnum, viper.generatortests.SimplestEnum]
Note: CompleteEnum: Gathering information for code generation
Note: CompleteEnum: Class prefix for generated classes will be "CompleteEnum"
Note: CompleteEnum: Will generate producers for primitive types
```
Which prepends the currently processing class name to the message.

Closes #22