### PR TITLE
Customize generated annotation and configuration bean

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,12 @@ import viper.PropertyFileResolver;
  * Character, Short, Integer, Long, Float, Double, Boolean. Take this feature
  * with care: we don't verify if the transformation from string is possible,
  * exceptions may be thrown.
+ * 
+ * You can also specify the name of the generated annotation and configuration
+ * bean. You can put a star symbol in it, and the processor will replace it with
+ * the enum name.
  */
-@CdiConfiguration(producersForPrimitives = true)
+@CdiConfiguration(producersForPrimitives = true, annotationName = "MyConfig", configurationBeanName = "*ConfInjector")
 /*
  * Generate a Properties-based file-sourced configuration resolver with the
  * given configuration file's path

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -23,6 +23,14 @@
 			<groupId>org.apache.velocity</groupId>
 			<artifactId>velocity</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/generator/src/main/resources/Configuration.vm
+++ b/generator/src/main/resources/Configuration.vm
@@ -17,7 +17,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({FIELD,TYPE,METHOD,PARAMETER})
 @Generated("$generatorName")
-public @interface ${enumClass}Configuration {
+public @interface ${annotationName} {
 	@Nonbinding
 	${enumClass} value() default ${enumClass}.${defaultKey};
 }

--- a/generator/src/main/resources/ConfigurationBean.vm
+++ b/generator/src/main/resources/ConfigurationBean.vm
@@ -17,7 +17,7 @@ import viper.ConfigurationResolver;
 @$annotation
 #end
 @Generated("$generatorName")
-public class ${enumClass}ConfigurationBean {
+public class ${configurationBeanName} {
 
 	@Inject
 	ConfigurationResolver<${enumClass}> resolver;
@@ -53,12 +53,12 @@ public class ${enumClass}ConfigurationBean {
 	}
 	
 	private ${enumClass} getEnumFromInjectionPoint(InjectionPoint ip) {
-		${enumClass}Configuration annotation = ip.getAnnotated().getAnnotation(${enumClass}Configuration.class);
+		${annotationName} annotation = ip.getAnnotated().getAnnotation(${annotationName}.class);
 		return annotation.value();
 	}
 
 	@Produces
-	@${enumClass}Configuration
+	@${annotationName}
 	private String getStringProperty(InjectionPoint ip) {
 		${enumClass} keyEnum = getEnumFromInjectionPoint(ip);
 		return getProperty(keyEnum);
@@ -67,7 +67,7 @@ public class ${enumClass}ConfigurationBean {
 #if ( $producersForPrimitives )
 #foreach ($type in ["Byte", "Short", "Integer", "Long", "Float", "Double", "Boolean"])
 	@Produces
-	@${enumClass}Configuration
+	@${annotationName}
 	private ${type} get${type}Property(InjectionPoint ip) {
 		String stringProperty = getStringProperty(ip);
 		return ${type}.valueOf(stringProperty);
@@ -75,7 +75,7 @@ public class ${enumClass}ConfigurationBean {
 #end
 	
 	@Produces
-	@${enumClass}Configuration
+	@${annotationName}
 	private Character getCharacterProperty(InjectionPoint ip) {
 		String stringProperty = getStringProperty(ip);
 		return stringProperty.charAt(0);

--- a/generator/src/test/java/viper/generator/ConfigurationKeyProcessorTest.java
+++ b/generator/src/test/java/viper/generator/ConfigurationKeyProcessorTest.java
@@ -1,0 +1,90 @@
+package viper.generator;
+
+import static viper.generator.ConfigurationKeyProcessor.calculateAnnotationName;
+import static viper.generator.ConfigurationKeyProcessor.calculateConfigurationBeanName;
+
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ConfigurationKeyProcessorTest {
+
+	private static final String ENUM_CLASS = "EnumBase";
+	@Rule
+	public JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+	@Test
+	public void shouldFailForNullString_annotationName() throws Exception {
+		softly.assertThatThrownBy(() -> calculateAnnotationName(null, null))
+				.isInstanceOf(IllegalArgumentException.class);
+		softly.assertThatThrownBy(() -> calculateAnnotationName("Clazz", null))
+				.isInstanceOf(IllegalArgumentException.class);
+		softly.assertThatThrownBy(() -> calculateAnnotationName(null, "ClazzAnnot"))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void shouldFailForInvalidString_annotationName() throws Exception {
+		softly.assertThatThrownBy(() -> calculateAnnotationName(ENUM_CLASS, ""))
+				.isInstanceOf(IllegalArgumentException.class);
+		softly.assertThatThrownBy(() -> calculateAnnotationName(ENUM_CLASS, "**yo"))
+				.isInstanceOf(IllegalArgumentException.class);
+		softly.assertThatThrownBy(() -> calculateAnnotationName(ENUM_CLASS, "yo***"))
+				.isInstanceOf(IllegalArgumentException.class);
+		softly.assertThatThrownBy(() -> calculateAnnotationName(ENUM_CLASS, "*yo*"))
+				.isInstanceOf(IllegalArgumentException.class);
+		softly.assertThatThrownBy(() -> calculateAnnotationName(ENUM_CLASS, "ma**yo"))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void shouldReplaceWithEnumName_annotationName() throws Exception {
+		softly.assertThat(calculateAnnotationName(ENUM_CLASS, "*Annotation")).isEqualTo(ENUM_CLASS + "Annotation");
+		softly.assertThat(calculateAnnotationName(ENUM_CLASS, "Annotation*")).isEqualTo("Annotation" + ENUM_CLASS);
+		softly.assertThat(calculateAnnotationName(ENUM_CLASS, "Anno*Tation")).isEqualTo("Anno" + ENUM_CLASS + "Tation");
+	}
+
+	@Test
+	public void shouldGenerateExactName_annotatioName() throws Exception {
+		softly.assertThat(calculateAnnotationName(ENUM_CLASS, "EnumBaseAnnotation")).isEqualTo("EnumBaseAnnotation");
+		softly.assertThat(calculateAnnotationName(ENUM_CLASS, "CustomAnnotation")).isEqualTo("CustomAnnotation");
+	}
+
+	@Test
+	public void shouldFailForNullString_configurationBeanName() throws Exception {
+		softly.assertThatThrownBy(() -> calculateConfigurationBeanName(null, null))
+				.isInstanceOf(IllegalArgumentException.class);
+		softly.assertThatThrownBy(() -> calculateConfigurationBeanName("Clazz", null))
+				.isInstanceOf(IllegalArgumentException.class);
+		softly.assertThatThrownBy(() -> calculateConfigurationBeanName(null, "ClazzAnnot"))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void shouldFailForInvalidString_configurationBeanName() throws Exception {
+		softly.assertThatThrownBy(() -> calculateConfigurationBeanName(ENUM_CLASS, ""))
+				.isInstanceOf(IllegalArgumentException.class);
+		softly.assertThatThrownBy(() -> calculateConfigurationBeanName(ENUM_CLASS, "**yo"))
+				.isInstanceOf(IllegalArgumentException.class);
+		softly.assertThatThrownBy(() -> calculateConfigurationBeanName(ENUM_CLASS, "yo***"))
+				.isInstanceOf(IllegalArgumentException.class);
+		softly.assertThatThrownBy(() -> calculateConfigurationBeanName(ENUM_CLASS, "*yo*"))
+				.isInstanceOf(IllegalArgumentException.class);
+		softly.assertThatThrownBy(() -> calculateConfigurationBeanName(ENUM_CLASS, "ma**yo"))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	public void shouldReplaceWithEnumName_configurationBeanName() throws Exception {
+		softly.assertThat(calculateConfigurationBeanName(ENUM_CLASS, "*ConfBean")).isEqualTo(ENUM_CLASS + "ConfBean");
+		softly.assertThat(calculateConfigurationBeanName(ENUM_CLASS, "ConfBean*")).isEqualTo("ConfBean" + ENUM_CLASS);
+		softly.assertThat(calculateConfigurationBeanName(ENUM_CLASS, "Anno*Tation"))
+				.isEqualTo("Anno" + ENUM_CLASS + "Tation");
+	}
+
+	@Test
+	public void shouldGenerateExactName_configurationBeanName() throws Exception {
+		softly.assertThat(calculateConfigurationBeanName(ENUM_CLASS, "EnumBaseConfBean")).isEqualTo("EnumBaseConfBean");
+		softly.assertThat(calculateConfigurationBeanName(ENUM_CLASS, "CustomConfBean")).isEqualTo("CustomConfBean");
+	}
+}

--- a/generatortests/src/test/java/viper/generatortests/CompleteEnum.java
+++ b/generatortests/src/test/java/viper/generatortests/CompleteEnum.java
@@ -19,8 +19,12 @@ import viper.PropertyFileResolver;
  * Character, Short, Integer, Long, Float, Double, Boolean. Take this feature
  * with care: we don't verify if the transformation from string is possible,
  * exceptions may be thrown.
+ * 
+ * You can also specify the name of the generated annotation and configuration
+ * bean. You can put a star symbol in it, and the processor will replace it with
+ * the enum name.
  */
-@CdiConfiguration(producersForPrimitives = true)
+@CdiConfiguration(producersForPrimitives = true, annotationName = "MyConfig", configurationBeanName = "*ConfInjector")
 /*
  * Generate a Properties-based file-sourced configuration resolver with the
  * given configuration file's path

--- a/generatortests/src/test/java/viper/generatortests/CompleteEnumTest.java
+++ b/generatortests/src/test/java/viper/generatortests/CompleteEnumTest.java
@@ -146,10 +146,10 @@ public class CompleteEnumTest {
 			.collect(toList());
 
 		assertThat(javaGeneratedFiles)
-			.as("Could generate annotation, configuration bean, and property file config resolver")
+			.as("Should generate annotation, configuration bean, and property file config resolver")
 			.contains(
-					enumClassName + "Configuration.java", // the annotation
-					enumClassName + "ConfigurationBean.java", // the injection
+					"MyConfig.java", // the annotation
+					enumClassName + "ConfInjector.java", // the injection bean
 					enumClassName + "PropertyFileConfigurationResolver.java" // the property file resolver
 				);
 		annotationProcessorHasRunSuccessfully = true;
@@ -159,7 +159,7 @@ public class CompleteEnumTest {
 	@Test
 	public void shouldGenerateConfigurationBeanClass() throws Exception {
 		assumingAnnotationProcessorHasRun();
-		String className = packageName + "." + enumClassName + "ConfigurationBean";
+		String className = packageName + "." + enumClassName + "ConfInjector";
 		Class<?> confBeanClass = tryLoadClassFromCompiledFiles(className).orElse(null);
 		assertThat(confBeanClass)
 			.isNotNull()
@@ -191,8 +191,8 @@ public class CompleteEnumTest {
 	public void shouldGenerateAllProducerMethodsForConfigurationBean() throws Exception {
 		assumingAnnotationProcessorHasRun();
 		
-		String beanClassName = packageName + "." + enumClassName + "ConfigurationBean";
-		String annotationClassName = packageName + "." + enumClassName + "Configuration";
+		String beanClassName = packageName + "." + enumClassName + "ConfInjector";
+		String annotationClassName = packageName + ".MyConfig";
 
 		Optional<Class<?>> beanClass = tryLoadClassFromCompiledFiles(beanClassName);
 		Optional<Class<? extends Annotation>> annotationClass = tryLoadClassFromCompiledFiles(annotationClassName);
@@ -226,7 +226,7 @@ public class CompleteEnumTest {
 	@Test
 	public void shouldGenerateConfigurationAnnotation() throws Exception {
 		assumingAnnotationProcessorHasRun();
-		String className = packageName + "." + enumClassName + "Configuration";
+		String className = packageName + "." + "MyConfig";
 		Class<?> confBeanClass = tryLoadClassFromCompiledFiles(className).orElse(null);
 		assertThat(confBeanClass)
 			.isAnnotation()
@@ -275,7 +275,7 @@ public class CompleteEnumTest {
 	@Test
 	public void shouldAddGeneratedAnnotationToGeneratedSourceCode_configurationBean() throws Exception {
 		assumingAnnotationProcessorHasRun();
-		File generatedConfigurationBean = findFileInGeneratedSources(enumClassName + "ConfigurationBean.java");
+		File generatedConfigurationBean = findFileInGeneratedSources(enumClassName + "ConfInjector.java");
 		CompilationUnit compilationUnit = JavaParser.parse(generatedConfigurationBean);
 		TypeDeclaration typeDeclaration = compilationUnit.getTypes().get(0);
 
@@ -286,7 +286,7 @@ public class CompleteEnumTest {
 	@Test
 	public void shouldAddGeneratedAnnotationToGeneratedSourceCode_configurationAnnotation() throws Exception {
 		assumingAnnotationProcessorHasRun();
-		File generatedConfigurationBean = findFileInGeneratedSources(enumClassName + "Configuration.java");
+		File generatedConfigurationBean = findFileInGeneratedSources("MyConfig.java");
 		CompilationUnit compilationUnit = JavaParser.parse(generatedConfigurationBean);
 		TypeDeclaration typeDeclaration = compilationUnit.getTypes().get(0);
 

--- a/generatortests/src/test/java/viper/generatortests/MultipleEnumCoexistenceTest.java
+++ b/generatortests/src/test/java/viper/generatortests/MultipleEnumCoexistenceTest.java
@@ -101,8 +101,8 @@ public class MultipleEnumCoexistenceTest {
 					+ "and property file config resolver for "
 					+ enumClassName)
 			.contains(
-					enumClassName + "Configuration.java", // the annotation
-					enumClassName + "ConfigurationBean.java", // the injection
+					"MyConfig.java", // the annotation
+					enumClassName + "ConfInjector.java", // the injection bean
 					enumClassName + "PropertyFileConfigurationResolver.java" // the property file resolver
 				);
 	}

--- a/library/src/main/java/viper/CdiConfiguration.java
+++ b/library/src/main/java/viper/CdiConfiguration.java
@@ -56,6 +56,22 @@ public @interface CdiConfiguration {
 	boolean producersForPrimitives() default false;
 
 	/**
+	 * Determine the generated annotation name. Defaults to
+	 * <code>*Configuration</code> which generates an annotation name like
+	 * <code>{EnumName}Configuration</code>. If you omit the star symbol, it
+	 * will create an annotation with the given name.
+	 */
+	String annotationName() default "*Configuration";
+
+	/**
+	 * Determine the generated configuration bean name. Defaults to
+	 * <code>*ConfigurationBean</code> which generates a configuration bean name
+	 * as <code>{EnumName}ConfigurationBean</code>. If you omit the star symbol,
+	 * it will create an annotation with the given name.
+	 */
+	String configurationBeanName() default "*ConfigurationBean";
+
+	/**
 	 * Specifies an enum constant to be used as the default constant. This will
 	 * be used to construct the qualifier annotation.
 	 */


### PR DESCRIPTION
Added two annotation fields to support for customizable names:
+ `annotationName` for annotation name. `*` is replaced with enum name,
defaults to current default which is `*Configuration`.
+ `configurationBeanName` for configuration bean. Same as above, the
default is the current default: `*ConfigurationBean`.

If you omit the `*` symbol, then the string will be the class/annotation name.

Should not impact current installations

Solves #46 