### PR TITLE
Add static factory methods to use viper generated classes directly

### DIFF
--- a/cditests/src/test/java/viper/cditests/NoCdiEnum.java
+++ b/cditests/src/test/java/viper/cditests/NoCdiEnum.java
@@ -1,0 +1,11 @@
+package viper.cditests;
+
+import viper.CdiConfiguration;
+import viper.PropertyFileResolver;
+
+@CdiConfiguration(producersForPrimitives=true)
+@PropertyFileResolver(propertiesPath="NoCdiEnum.properties")
+public enum NoCdiEnum {
+	NAME,
+	AGE
+}

--- a/cditests/src/test/java/viper/cditests/NoCdiEnumTest.java
+++ b/cditests/src/test/java/viper/cditests/NoCdiEnumTest.java
@@ -1,0 +1,39 @@
+package viper.cditests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class NoCdiEnumTest {
+	private static final int CUSTOM_AGE = 42;
+	private static final String CUSTOM_NAME = "Obama";
+	private static final String CUSTOM_PROPERTIES_FILENAME = "custom.properties";
+	@Rule
+	public TemporaryFolder temp = new TemporaryFolder();
+	private String customPath;
+
+	@Before
+	public void setup() throws Exception {
+		Properties props = new Properties();
+		props.setProperty(NoCdiEnum.AGE.name().toLowerCase(), "42");
+		props.setProperty(NoCdiEnum.NAME.name().toLowerCase(), CUSTOM_NAME);
+		File customPropertiesFile = temp.newFile(CUSTOM_PROPERTIES_FILENAME);
+		customPath = customPropertiesFile.getAbsolutePath();
+		props.store(new FileOutputStream(customPropertiesFile), null);
+	}
+
+	@Test
+	public void shouldReadFromTempDirUsingManualInstantiation() throws Exception {
+		NoCdiEnumConfigurationBean configurationBean = NoCdiEnumConfigurationBean
+				.create(NoCdiEnumPropertyFileConfigurationResolver.create(customPath));
+		assertThat(configurationBean.getProperty(NoCdiEnum.NAME)).isEqualTo(CUSTOM_NAME);
+		assertThat(configurationBean.getIntegerProperty(NoCdiEnum.AGE)).isEqualTo(CUSTOM_AGE);
+	}
+}

--- a/generator/src/main/resources/ConfigurationBean.vm
+++ b/generator/src/main/resources/ConfigurationBean.vm
@@ -20,9 +20,9 @@ import viper.ConfigurationResolver;
 public class ${configurationBeanName} {
 
 	@Inject
-	ConfigurationResolver<${enumClass}> resolver;
-
+	private ConfigurationResolver<${enumClass}> resolver;
 #if ( $validator )
+
 	@PostConstruct
 	void validateProperties() {
 		ArrayList<String> invalid= new ArrayList<>();
@@ -48,6 +48,15 @@ public class ${configurationBeanName} {
 	}
 #end
 
+	public static ${configurationBeanName} create(ConfigurationResolver<${enumClass}> resolver) {
+		${configurationBeanName} instance = new ${configurationBeanName}();
+		instance.resolver = resolver;
+#if ( $validator )
+		instance.validateProperties();
+#end
+		return instance;
+	}
+
 	public String getProperty(${enumClass} keyEnum) {
 		return resolver.getConfigurationValue(keyEnum);
 	}
@@ -63,22 +72,31 @@ public class ${configurationBeanName} {
 		${enumClass} keyEnum = getEnumFromInjectionPoint(ip);
 		return getProperty(keyEnum);
 	}
-
 #if ( $producersForPrimitives )
 #foreach ($type in ["Byte", "Short", "Integer", "Long", "Float", "Double", "Boolean"])
+	public ${type} get${type}Property(${enumClass} keyEnum) {
+		String stringProperty = getProperty(keyEnum);
+		return ${type}.valueOf(stringProperty);
+	}
+
 	@Produces
 	@${annotationName}
 	private ${type} get${type}Property(InjectionPoint ip) {
-		String stringProperty = getStringProperty(ip);
-		return ${type}.valueOf(stringProperty);
+		${enumClass} keyEnum = getEnumFromInjectionPoint(ip);
+		return get${type}Property(keyEnum);
 	}
 #end
-	
+
+	public Character getCharacterProperty(${enumClass} keyEnum) {
+		String stringProperty = getProperty(keyEnum);
+		return stringProperty.charAt(0);
+	}
+
 	@Produces
 	@${annotationName}
 	private Character getCharacterProperty(InjectionPoint ip) {
-		String stringProperty = getStringProperty(ip);
-		return stringProperty.charAt(0);
+		${enumClass} keyEnum = getEnumFromInjectionPoint(ip);
+		return getCharacterProperty(keyEnum);
 	}
 #end
 }

--- a/generator/src/main/resources/ConfigurationResolver.vm
+++ b/generator/src/main/resources/ConfigurationResolver.vm
@@ -21,7 +21,17 @@ public class ${enumClass}PropertyFileConfigurationResolver implements Configurat
 	void init() {
 		properties = getAvailableProperties(PROPERTIES_PATH);
 	}
-	
+
+	public static ${enumClass}PropertyFileConfigurationResolver create(String propertiesPath) {
+		${enumClass}PropertyFileConfigurationResolver instance = new ${enumClass}PropertyFileConfigurationResolver();
+		instance.properties = getAvailableProperties(propertiesPath);
+		return instance;
+	}
+
+	public static ${enumClass}PropertyFileConfigurationResolver create() {
+		return create(PROPERTIES_PATH);
+	}
+
 	@Override
 	public String getConfigurationValue(${enumClass} key) {
 		return properties.getProperty(enumToKeyString(key));


### PR DESCRIPTION
You will still need CDI in the classpath, but you can also create an
instance of the classes via the factory methods.

Velocity templates has been modified to ensure that primitive-type configurations are available in the generated ConfigurationBean interface.

Closes #29 